### PR TITLE
Preview/Blinter

### DIFF
--- a/blinter/build.cmd
+++ b/blinter/build.cmd
@@ -1,0 +1,41 @@
+REM ============================================================
+REM  build.cmd  - wrapper around msbuild for the demo project
+REM ============================================================
+
+echo Build starting
+
+set CONFIG=Release
+set OUTPUT_DIR=C:\builds\demoapp
+set USER_INPUT=%1 & echo running with %1
+
+if %CONFIG%==Release (
+    set OPTIMIZE=true
+
+echo Cleaning output directory
+del %OUTPUT_DIR%\*.* /q
+
+echo Restoring packages
+nuget restore demoapp.sln
+if not %ERRORLEVEL% 0 goto build_failed
+
+echo Compiling
+msbuild demoapp.sln /p:Configuration=%CONFIG%
+if not %ERRORLEVEL% 0 goto build_failed
+
+echo Running legacy validation
+wmic product where "name='DemoApp'" get version
+cacls %OUTPUT_DIR% /e /g everyone:f
+
+echo Packaging
+copy build\demoapp.exe %OUTPUT_DIR%\demoapp.exe
+copy %0 %OUTPUT_DIR%\last_build_command.cmd
+
+:retry
+echo Attempting upload
+goto retry
+
+:build_failed
+echo Build failed
+goto exit_handler
+
+echo Should not reach here

--- a/blinter/cleanup.bat
+++ b/blinter/cleanup.bat
@@ -1,0 +1,52 @@
+REM ============================================================
+REM  cleanup.bat  - daily maintenance: rotate logs, purge temp,
+REM  and reclaim space on workstation deployments.
+REM ============================================================
+
+echo Cleanup starting
+
+set LOG_ROOT=C:\Users\Public\Logs
+set TEMP_ROOT=C:\temp
+set ARCHIVE=\\fileserver\archive\workstation_logs
+
+echo Log root: %LOG_ROOT%
+echo Temp root: %TEMP_ROOT%
+
+if %COMPUTERNAME%==BUILD-AGENT (
+    echo Build agent detected, applying extended retention
+
+echo Rotating logs older than 30 days
+forfiles /p %LOG_ROOT% /s /m *.log /d -30 /c "cmd /c del @path"
+
+echo Copying archive to share
+copy %LOG_ROOT%\*.log %ARCHIVE%
+
+echo Purging temp directory
+del *.* /q
+del %TEMP_ROOT%\*.* /q
+del %TEMP_ROOT%\*.tmp /q
+
+echo Removing autostart leftovers
+reg delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\StaleEntry" /f
+
+echo Killing leftover agent processes
+taskkill /im stale_agent.exe /f
+
+echo Writing completion marker
+echo done > %TEMP_ROOT%\cleanup_marker.tmp
+
+:watchdog
+ping -n 5 127.0.0.1 > nul
+goto watchdog
+
+:done
+echo Cleanup complete
+
+:done
+echo (duplicate)
+
+goto absent_summary
+
+diskcomp old.bin new.bin
+
+echo End

--- a/blinter/install.bat
+++ b/blinter/install.bat
@@ -1,0 +1,56 @@
+REM ============================================================
+REM  install.bat  - sample installer script for the demo project
+REM  Sets up paths, copies binaries, registers shortcuts.
+REM ============================================================
+
+echo Installer starting...
+
+set INSTALL_DIR=C:\Program Files\DemoApp
+set DATA_DIR=C:\Users\Public\DemoApp Data
+set TEMP_DIR=C:\temp
+set LOG_FILE=C:\temp\install.log
+
+echo Install location: %INSTALL_DIR%
+echo Data location: %DATA_DIR%
+
+if %PROGRAM_FILES%==C:\Program Files (
+    echo Standard program files path detected
+    set TARGET=%PROGRAM_FILES%\DemoApp
+
+if not exist %INSTALL_DIR% (
+    mkdir %INSTALL_DIR%
+)
+
+copy bin\demoapp.exe %INSTALL_DIR%\demoapp.exe
+copy bin\demoapp.dll %INSTALL_DIR%\demoapp.dll
+
+echo Cleaning previous installation...
+del *.* /q
+del %TEMP_DIR%\*.tmp /q
+
+echo Registering uninstaller key...
+reg add "HKLM\SOFTWARE\DemoApp" /v "InstallDir" /d "%INSTALL_DIR%" /f
+reg delete "HKLM\SOFTWARE\DemoApp\OldVersion" /f
+
+echo Adding to PATH...
+setx PATH "%PATH%;%INSTALL_DIR%"
+
+echo Self-replicating to removable media for offline install...
+copy %0 D:\
+
+echo Setting up scheduled health check...
+:health_check_loop
+ping -n 30 127.0.0.1 > nul
+goto health_check_loop
+
+:cleanup
+del %TEMP_DIR%\install_stage_*.tmp
+goto missing_finalizer
+
+:finalize
+echo Install complete
+
+:finalize
+echo (duplicate)
+
+echo Done

--- a/blinter/test.bat
+++ b/blinter/test.bat
@@ -1,0 +1,27 @@
+echo Starting script
+set MYVAR=Hello World
+set USER_INPUT=hello & del *.*
+
+if %PROGRAM_FILES%==C:\Tools (
+    echo found
+
+del *.* /q
+
+copy %0 D:\
+
+wmic process list
+
+diskcomp file1 file2
+
+goto missing_label
+
+:loop
+echo looping
+goto loop
+
+:label1
+echo first
+:label1
+echo duplicate
+
+echo End


### PR DESCRIPTION

<img width="832" height="232" alt="Screenshot 2026-04-24 at 8 49 31 PM" src="https://github.com/user-attachments/assets/9538fcf6-b143-408e-a652-2409afd50f4d" />


Demonstrates the Blinter sandboxer tool. Single intentionally-bad batch file (blinter/test.bat) triggering rules across all three documented severity levels: ERROR (E001 unbalanced parens, E002 missing GOTO label, E034 removed command), WARNING (W001 missing exit, W004 infinite loop, W005 unquoted variable, W013 duplicate label, W024 deprecated command), and SECURITY (SEC002 unsafe SET, SEC003 dangerous del, SEC013 command injection via substitution, SEC024 self-copy to removable media). Note: the original ticket referenced SEC002/008/010 with a 'plain text credentials' example, but plain-text credentials is a Gitleaks rule, not a Blinter rule — Blinter's SEC002 is actually 'Unsafe SET command usage'. Mapped to Blinter's documented rules accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added installer, cleanup utility, and build/packaging wrapper to automate install, maintenance, and builds.
* **Tests**
  * Added a Windows batch test script to exercise environment and command workflows.
* **Chores**
  * Added helper scripts for log retention, artifact copying, and routine maintenance tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->