### PR TITLE
Preview/Trivy

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,8 @@
+reviews:
+  tools:
+    checkov:
+      enabled: false
+    hadolint:
+      enabled: false
+    gitleaks:
+      enabled: false

--- a/trivy/Dockerfile
+++ b/trivy/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    python3 \
+    python3-pip \
+    openssh-server
+
+ADD https://example.com/installer/demoapp-bundle.tar.gz /tmp/bundle.tar.gz
+
+RUN tar -xzf /tmp/bundle.tar.gz -C /opt
+
+COPY . /app
+
+WORKDIR /app
+
+RUN pip3 install -r requirements.txt
+
+EXPOSE 22 80 443
+
+CMD ["python3", "/app/server.py"]

--- a/trivy/Dockerfile.legacy
+++ b/trivy/Dockerfile.legacy
@@ -1,0 +1,13 @@
+FROM ubuntu:latest
+
+ENV API_TOKEN=internal_token_2c8b41d9c0a64e1e9b0f3e7a1d5c8b41
+ENV AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+ENV AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+RUN apt-get update && apt-get install -y curl
+
+COPY . /app
+
+EXPOSE 22
+
+CMD ["/app/legacy-agent"]

--- a/trivy/iam.tf
+++ b/trivy/iam.tf
@@ -1,0 +1,51 @@
+resource "aws_iam_policy" "wildcard_admin" {
+  name        = "demoapp-wildcard-admin"
+  description = "Broad admin policy for demoapp service workers"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "*"
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:*", "iam:PassRole", "kms:Decrypt"]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "service" {
+  name = "demoapp-service-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "service_admin" {
+  role       = aws_iam_role.service.name
+  policy_arn = aws_iam_policy.wildcard_admin.arn
+}
+
+resource "aws_iam_user" "ci" {
+  name = "demoapp-ci"
+}
+
+resource "aws_iam_user_policy_attachment" "ci_admin" {
+  user       = aws_iam_user.ci.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/trivy/main.tf
+++ b/trivy/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket = "demoapp-artifacts-prod"
+}
+
+resource "aws_s3_bucket_acl" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_public_access_block" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "demoapp-logs-prod"
+}
+
+resource "aws_s3_bucket_versioning" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+}

--- a/trivy/network.tf
+++ b/trivy/network.tf
@@ -1,0 +1,50 @@
+resource "aws_security_group" "web" {
+  name        = "demoapp-web"
+  description = "Public web tier security group"
+  vpc_id      = "vpc-0123456789abcdef0"
+
+  ingress {
+    description = "SSH from anywhere"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "RDP from anywhere"
+    from_port   = 3389
+    to_port     = 3389
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "All TCP"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_db_instance" "primary" {
+  identifier             = "demoapp-primary"
+  engine                 = "postgres"
+  engine_version         = "14.7"
+  instance_class         = "db.t3.medium"
+  allocated_storage      = 20
+  username               = "demoapp"
+  password               = "Sup3rS3cr3tP@ssword"
+  publicly_accessible    = true
+  storage_encrypted      = false
+  skip_final_snapshot    = true
+  vpc_security_group_ids = [aws_security_group.web.id]
+}

--- a/trivy/secrets.tf
+++ b/trivy/secrets.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  alias      = "deploy"
+  region     = "us-west-2"
+  access_key = "AKIAIOSFODNN7EXAMPLE"
+  secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+}
+
+resource "aws_ssm_parameter" "datadog_key" {
+  name  = "/demoapp/observability/datadog_api_key"
+  type  = "String"
+  value = "1234567890abcdef1234567890abcdef"
+}
+
+resource "aws_ssm_parameter" "internal_token" {
+  name  = "/demoapp/internal/service_token"
+  type  = "String"
+  value = "internal_token_2c8b41d9c0a64e1e9b0f3e7a1d5c8b41"
+}
+
+resource "aws_db_instance_password" "fallback" {
+  password = "Sup3rS3cr3tP@ssword"
+}

--- a/trivy/terraform.tfvars
+++ b/trivy/terraform.tfvars
@@ -1,0 +1,6 @@
+environment       = "production"
+region            = "us-east-1"
+db_username       = "demoapp"
+db_password       = "Sup3rS3cr3tP@ssword"
+admin_api_token   = "internal_token_2c8b41d9c0a64e1e9b0f3e7a1d5c8b41"
+private_key_pem   = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAyqXmSVk3...truncated...AAAA\n-----END RSA PRIVATE KEY-----"


### PR DESCRIPTION
Demonstrates the Trivy sandboxer tool. Includes Terraform (S3 unencrypted+public, IAM wildcard policy, public RDS, open security groups) and Dockerfile samples (root user, ADD with URL, baked-in AWS credentials) targeting Trivy HIGH and CRITICAL rules so findings surface under the CHILL review profile. Repo-level .coderabbit.yml disables Checkov, Hadolint, and Gitleaks to avoid shadowing Trivy on overlapping checks. Fake credentials use AWS docs canonical example keys (allowlisted by GitHub push protection).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added container image build configuration files for service deployment.
  * Added cloud infrastructure provisioning configuration including storage, database, security, and IAM resources.
  * Added secrets and credentials management setup.
  * Added review tool configuration to disable specific checkers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->